### PR TITLE
feat: add workshop type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Angular Conferences Worldwide
 
 ---
 
-> This repo contains the world's best Angular Conferences and meetups, if you host an event and would like to be listed please follow the steps below:
+> This repo contains the world's best Angular Conferences, meetups and workshops, if you host an event and would like to be listed please follow the steps below:
 
 [Add Your Event](#add-your-event)
 
@@ -40,7 +40,7 @@ Use the guide below to add your own event to the correct month inside the above 
     // Please compress SVG before your PR:
     // https://jakearchibald.github.io/svgomg/
     "logo": "ngbe.svg",
-    // The type of event, "conference" or "meetup"
+    // The type of event, "conference", "meetup", or "workshop"
     "type": "conference",
     // A *short* description of your event, max 400 characters.
     "desc": "NG-BE 2018 is a 2-day event in Ghent, Belgium, that brings together Angular developers and experts from all over the world to share ideas, news and opinions about Angular."

--- a/_includes/calendar.html
+++ b/_includes/calendar.html
@@ -8,7 +8,8 @@
     <p>Show:</p>
     <a href="#all" class="active">All</a> <span>&bull;</span>
     <a href="#conference">Conferences</a> <span>&bull;</span>
-    <a href="#meetup">Meetups</a>
+    <a href="#meetup">Meetups</a> <span>&bull;</span>
+    <a href="#workshop">Workshops</a>
   </div>
   {% for conf in assets %}
     {% if conf[1].size > 0 %}
@@ -18,7 +19,7 @@
         {% for item in conf[1] %}
         {% assign month = conf[0] %}
         {% assign year = include.year %}
-          {% 
+          {%
             include generic/conference.html
             month=month
             year=year

--- a/_includes/generic/conference.html
+++ b/_includes/generic/conference.html
@@ -483,10 +483,10 @@
     {% assign country = "Zimbabwe" %}
 {% endcase %}
 
-<div class="ac-box toggle-modal active"{% if item.metadata.type == 'conference' or item.metadata.type == 'meetup' %}data-event-type="{{ item.metadata.type }}"{% endif %}>
+<div class="ac-box toggle-modal active"{% if item.metadata.type == 'conference' or item.metadata.type == 'meetup' or item.metadata.type == 'workshop' %}data-event-type="{{ item.metadata.type }}"{% endif %}>
   <h3 class="ac-box-title">
     {{ item.metadata.title }}
-    <span>{% if item.metadata.type == 'conference' or item.metadata.type == 'meetup' %}{{ item.metadata.type }}{% endif %}</span>
+    <span>{% if item.metadata.type == 'conference' or item.metadata.type == 'workshop' or item.metadata.type == 'meetup' %}{{ item.metadata.type }}{% endif %}</span>
   </h3>
   <div class="ac-box-date">
     <p>
@@ -498,7 +498,7 @@
       <span>&bull;</span>
       <img class="ac-box-flag" src="/assets/img/flags/{{ item.metadata.country_code | downcase }}.svg">
       {% if item.metadata.location and item.metadata.location != '' %}
-        {{ item.metadata.location }}, 
+        {{ item.metadata.location }},
       {% endif %}
       {{ country }}
     </p>

--- a/_includes/generic/modal.html
+++ b/_includes/generic/modal.html
@@ -493,7 +493,7 @@
       <div>
         <h3 class="modal-person-name">
           {{ item.metadata.title }}
-          <span>{% if item.metadata.type == 'conference' or item.metadata.type == 'meetup' %}{{ item.metadata.type }}{% endif %}</span>
+          <span>{% if item.metadata.type == 'conference' or item.metadata.type == 'workshop' or item.metadata.type == 'meetup' %}{{ item.metadata.type }}{% endif %}</span>
         </h3>
         <p class="modal-person-title">
           {% if item.metadata.date == '' %}

--- a/_scripts/app.js
+++ b/_scripts/app.js
@@ -116,6 +116,7 @@
             break;
           }
           case 'conference':
+          case 'workshop':
           case 'meetup': {
             confs.map(conf => {
               if (conf.getAttribute(`${EVENT_TYPE}`) === value) {


### PR DESCRIPTION
This PR adds the `workshop` type, because we were not able to list Angular in Flip Flops because it's not a conference nor a meetup.

Once there is a `workshop` type we can send another PR for adding AiFF.

Any thoughts on this one? I was talking to @anacidre about the new type so I went ahead and found all necessary places that needed to be updated.

This PR was also locally tested and it works like a charm! Here's how it looks:

![image](https://user-images.githubusercontent.com/12571019/45948642-197a2f80-bff9-11e8-8f57-39393d85f774.png)
